### PR TITLE
CONTRIB-3290-groupmode-validation_19_STABLE

### DIFF
--- a/lang/en_utf8/adobeconnect.php
+++ b/lang/en_utf8/adobeconnect.php
@@ -101,5 +101,6 @@ $string['invalidurl'] = 'The URL needs to start with a letter (a-z)';
 $string['longurl'] = 'That meeting URL is too long. Try shortening it';
 $string['errorrecording'] = 'Unable to find recording session';
 $string['meetinfo'] = 'More Meeting Detail';
-$string['meetinfotxt'] = 'See server meeting details'
+$string['meetinfotxt'] = 'See server meeting details';
+$string['invalidgroupmode'] = 'Your course site has no groups set up. Please set some up or select \'No groups\''
 ?>

--- a/lang/en_utf8/adobeconnect.php
+++ b/lang/en_utf8/adobeconnect.php
@@ -102,5 +102,5 @@ $string['longurl'] = 'That meeting URL is too long. Try shortening it';
 $string['errorrecording'] = 'Unable to find recording session';
 $string['meetinfo'] = 'More Meeting Detail';
 $string['meetinfotxt'] = 'See server meeting details';
-$string['invalidgroupmode'] = 'Your course site has no groups set up. Please set some up or select \'No groups\''
+$string['invalidgroupmode'] = 'Your course has no groups. Please set some up or select \'No groups\''
 ?>

--- a/mod_form.php
+++ b/mod_form.php
@@ -116,7 +116,7 @@ class mod_adobeconnect_mod_form extends moodleform_mod {
     }
 
     function validation($data, $files) {
-        global $CFG, $USER;
+        global $CFG, $USER, $COURSE;
 
         $errors = parent::validation($data, $files);
 
@@ -179,6 +179,15 @@ class mod_adobeconnect_mod_form extends moodleform_mod {
             if (record_exists('adobeconnect', 'name', $data['name'])) {
                 $errors['name'] = get_string('duplicatemeetingname', 'adobeconnect');
                 return $errors;
+            }
+
+            // Check that the course has groups if group mode is on
+            if (0 != $data['groupmode']) { // Allow for multiple groups
+                // get all groups for the course
+                $crsgroups = groups_get_all_groups($COURSE->id);
+                if (empty($crsgroups)) {
+                    $errors['groupmode'] = get_string('invalidgroupmode', 'adobeconnect');
+                }
             }
 
             // Check Adobe connect server for duplicated names


### PR DESCRIPTION
Hi Akin,

Here's what I came up with for checking that users aren't trying to set up an Adobe Connect activity as a group activity if the course has no groups.

Cheers,
Jen
